### PR TITLE
Fix Mesh Bed Levelling

### DIFF
--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -443,7 +443,7 @@
 // Above this temperature the heater will be switched off.
 // This can protect components from overheating, but NOT from shorts and failures.
 // (Use MINTEMP for thermistor short/failure protection.)
-#define HEATER_0_MAXTEMP 295
+#define HEATER_0_MAXTEMP 300
 //#define HEATER_1_MAXTEMP 275
 //#define HEATER_2_MAXTEMP 275
 //#define HEATER_3_MAXTEMP 275
@@ -664,17 +664,18 @@
  *          TMC5130, TMC5130_STANDALONE, TMC5160, TMC5160_STANDALONE
  * :['A4988', 'A5984', 'DRV8825', 'LV8729', 'L6470', 'TB6560', 'TB6600', 'TMC2100', 'TMC2130', 'TMC2130_STANDALONE', 'TMC2160', 'TMC2160_STANDALONE', 'TMC2208', 'TMC2208_STANDALONE', 'TMC2209', 'TMC2209_STANDALONE', 'TMC26X', 'TMC26X_STANDALONE', 'TMC2660', 'TMC2660_STANDALONE', 'TMC5130', 'TMC5130_STANDALONE', 'TMC5160', 'TMC5160_STANDALONE']
  */
-#define X_DRIVER_TYPE  TMC2208 // comment out for stock drivers
-#define Y_DRIVER_TYPE  TMC2208 // comment out for stock drivers
-#define Z_DRIVER_TYPE  TMC2208 // comment out for stock drivers
-//#define X2_DRIVER_TYPE TMC2208_STANDALONE
-//#define Y2_DRIVER_TYPE TMC2208_STANDALONE
-#define Z2_DRIVER_TYPE TMC2208 // comment out for stock drivers
-#define E0_DRIVER_TYPE TMC2208 // comment out for stock drivers
-#define E1_DRIVER_TYPE TMC2208 // comment out for stock drivers
-//#define E2_DRIVER_TYPE TMC2208_STANDALONE
-//#define E3_DRIVER_TYPE TMC2208_STANDALONE
-//#define E4_DRIVER_TYPE TMC2208_STANDALONE
+#define X_DRIVER_TYPE TMC2208
+#define Y_DRIVER_TYPE TMC2208
+#define Z_DRIVER_TYPE TMC2208
+//#define X2_DRIVER_TYPE A4988
+//#define Y2_DRIVER_TYPE A4988
+//#define Z2_DRIVER_TYPE TMC2208
+//#define Z3_DRIVER_TYPE A4988
+//#define E0_DRIVER_TYPE TMC2208
+#define E1_DRIVER_TYPE TMC2208
+//#define E2_DRIVER_TYPE A4988
+//#define E3_DRIVER_TYPE A4988
+//#define E4_DRIVER_TYPE A4988
 //#define E5_DRIVER_TYPE A4988
 
 // Enable this feature if all enabled endstop pins are interrupt-capable.
@@ -1029,12 +1030,10 @@
 // @section extruder
 
 // For direct drive extruder v9 set to true, for geared extruder set to false.
-#define INVERT_E0_DIR true // set to false for stock drivers or TMC2208 with reversed connectors
-#define INVERT_E1_DIR false // set to false for stock drivers or TMC2208 with reversed connectors
-#define INVERT_E2_DIR true
-#define INVERT_E3_DIR true
-#define INVERT_E4_DIR true
-#define INVERT_E5_DIR true
+#define INVERT_E0_DIR false
+#define INVERT_E1_DIR false
+#define INVERT_E2_DIR false
+#define INVERT_E3_DIR false
 
 // @section homing
 
@@ -1055,15 +1054,15 @@
 
 // The size of the print bed
 #define X_BED_SIZE 410
-#define Y_BED_SIZE 415
+#define Y_BED_SIZE 395
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS -10
-#define Y_MIN_POS 0
+#define Y_MIN_POS -15
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE
-#define Z_MAX_POS 453
+#define Z_MAX_POS 455
 
 /**
  * Software Endstops
@@ -1166,9 +1165,9 @@
  */
 //#define AUTO_BED_LEVELING_3POINT
 //#define AUTO_BED_LEVELING_LINEAR
-#define AUTO_BED_LEVELING_BILINEAR
+//#define AUTO_BED_LEVELING_BILINEAR
 //#define AUTO_BED_LEVELING_UBL
-//#define MESH_BED_LEVELING
+#define MESH_BED_LEVELING
 
 /**
  * Normally G28 leaves leveling disabled on completion. Enable

--- a/Marlin/Configuration.h
+++ b/Marlin/Configuration.h
@@ -443,7 +443,7 @@
 // Above this temperature the heater will be switched off.
 // This can protect components from overheating, but NOT from shorts and failures.
 // (Use MINTEMP for thermistor short/failure protection.)
-#define HEATER_0_MAXTEMP 300
+#define HEATER_0_MAXTEMP 295
 //#define HEATER_1_MAXTEMP 275
 //#define HEATER_2_MAXTEMP 275
 //#define HEATER_3_MAXTEMP 275
@@ -664,18 +664,17 @@
  *          TMC5130, TMC5130_STANDALONE, TMC5160, TMC5160_STANDALONE
  * :['A4988', 'A5984', 'DRV8825', 'LV8729', 'L6470', 'TB6560', 'TB6600', 'TMC2100', 'TMC2130', 'TMC2130_STANDALONE', 'TMC2160', 'TMC2160_STANDALONE', 'TMC2208', 'TMC2208_STANDALONE', 'TMC2209', 'TMC2209_STANDALONE', 'TMC26X', 'TMC26X_STANDALONE', 'TMC2660', 'TMC2660_STANDALONE', 'TMC5130', 'TMC5130_STANDALONE', 'TMC5160', 'TMC5160_STANDALONE']
  */
-#define X_DRIVER_TYPE TMC2208
-#define Y_DRIVER_TYPE TMC2208
-#define Z_DRIVER_TYPE TMC2208
-//#define X2_DRIVER_TYPE A4988
-//#define Y2_DRIVER_TYPE A4988
-//#define Z2_DRIVER_TYPE TMC2208
-//#define Z3_DRIVER_TYPE A4988
-//#define E0_DRIVER_TYPE TMC2208
-#define E1_DRIVER_TYPE TMC2208
-//#define E2_DRIVER_TYPE A4988
-//#define E3_DRIVER_TYPE A4988
-//#define E4_DRIVER_TYPE A4988
+#define X_DRIVER_TYPE  TMC2208 // comment out for stock drivers
+#define Y_DRIVER_TYPE  TMC2208 // comment out for stock drivers
+#define Z_DRIVER_TYPE  TMC2208 // comment out for stock drivers
+//#define X2_DRIVER_TYPE TMC2208_STANDALONE
+//#define Y2_DRIVER_TYPE TMC2208_STANDALONE
+#define Z2_DRIVER_TYPE TMC2208 // comment out for stock drivers
+#define E0_DRIVER_TYPE TMC2208 // comment out for stock drivers
+#define E1_DRIVER_TYPE TMC2208 // comment out for stock drivers
+//#define E2_DRIVER_TYPE TMC2208_STANDALONE
+//#define E3_DRIVER_TYPE TMC2208_STANDALONE
+//#define E4_DRIVER_TYPE TMC2208_STANDALONE
 //#define E5_DRIVER_TYPE A4988
 
 // Enable this feature if all enabled endstop pins are interrupt-capable.
@@ -1030,10 +1029,12 @@
 // @section extruder
 
 // For direct drive extruder v9 set to true, for geared extruder set to false.
-#define INVERT_E0_DIR false
-#define INVERT_E1_DIR false
-#define INVERT_E2_DIR false
-#define INVERT_E3_DIR false
+#define INVERT_E0_DIR true // set to false for stock drivers or TMC2208 with reversed connectors
+#define INVERT_E1_DIR false // set to false for stock drivers or TMC2208 with reversed connectors
+#define INVERT_E2_DIR true
+#define INVERT_E3_DIR true
+#define INVERT_E4_DIR true
+#define INVERT_E5_DIR true
 
 // @section homing
 
@@ -1054,15 +1055,15 @@
 
 // The size of the print bed
 #define X_BED_SIZE 410
-#define Y_BED_SIZE 395
+#define Y_BED_SIZE 415
 
 // Travel limits (mm) after homing, corresponding to endstop positions.
 #define X_MIN_POS -10
-#define Y_MIN_POS -15
+#define Y_MIN_POS 0
 #define Z_MIN_POS 0
 #define X_MAX_POS X_BED_SIZE
 #define Y_MAX_POS Y_BED_SIZE
-#define Z_MAX_POS 455
+#define Z_MAX_POS 453
 
 /**
  * Software Endstops

--- a/Marlin/src/lcd/anycubic_TFT.cpp
+++ b/Marlin/src/lcd/anycubic_TFT.cpp
@@ -28,6 +28,7 @@
 #include "../core/macros.h"
 #include "../core/serial.h"
 #include "../gcode/queue.h"
+#include "../feature/bedlevel/mbl/mesh_bed_leveling.h"
 #include "../feature/emergency_parser.h"
 #include "../feature/pause.h"
 #include "../inc/MarlinConfig.h"
@@ -1258,12 +1259,12 @@ void AnycubicTFTClass::GetCommandFromTFT()
                   if(CodeSeen('Y')) { y = CodeValue(); }
 
                   ANYCUBIC_SERIAL_PROTOCOLPGM("A29V ");
-                  ANYCUBIC_SERIAL_PROTOCOL_F( LINEAR_UNIT(z_values[x][y]) * 100, 3 );
+                  ANYCUBIC_SERIAL_PROTOCOL_F( LINEAR_UNIT(mbl.z_values[x][y]) * 100, 3 );
                   ANYCUBIC_SERIAL_ENTER();
                   #ifdef ANYCUBIC_TFT_DEBUG
                     
                     SERIAL_ECHOPGM("A29V ");
-                    SERIAL_ECHO_F( LINEAR_UNIT(z_values[x][y]), 5 );
+                    SERIAL_ECHO_F( LINEAR_UNIT(mbl.z_values[x][y]), 5 );
                     SERIAL_ECHOLNPGM(">");
                   #endif
 
@@ -1351,7 +1352,7 @@ void AnycubicTFTClass::GetCommandFromTFT()
                     tempZ += value;
                     for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
                       for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++) {
-                        z_values[x][y] += value;
+                        mbl.z_values[x][y] += value;
                       }
                     
                     ANYCUBIC_SERIAL_PROTOCOLPGM("A31V ");
@@ -1364,7 +1365,7 @@ void AnycubicTFTClass::GetCommandFromTFT()
                       SERIAL_ECHO(tempZ);
                       SERIAL_ECHOLNPGM(">");
                     #endif
-                    refresh_bed_level();
+                    reset_bed_level();
                   }
                   if(CodeSeen('G'))
                   {
@@ -1379,7 +1380,7 @@ void AnycubicTFTClass::GetCommandFromTFT()
                     #endif
                     for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
                       for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++) {
-                        temp_z_values[x][y] = z_values[x][y];
+                        temp_z_values[x][y] = mbl.z_values[x][y];
                       }
                   }
                   if(CodeSeen('D'))
@@ -1389,7 +1390,7 @@ void AnycubicTFTClass::GetCommandFromTFT()
                     SERIAL_ECHOLNPGM(">");
                     for (uint8_t x = 0; x < GRID_MAX_POINTS_X; x++)
                       for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++) {
-                        z_values[x][y] = temp_z_values[x][y];
+                        mbl.z_values[x][y] = temp_z_values[x][y];
                       }
                       probe_offset.z = tempZ;
                       queue.enqueue_now_P(PSTR("M420 S1"));
@@ -1426,11 +1427,11 @@ void AnycubicTFTClass::GetCommandFromTFT()
             if(CodeSeen('V'))
             {
               temp_z_values[x][y] = (float)constrain(CodeValue()/100,-10,10);
-              refresh_bed_level();
+              reset_bed_level();
             }
             if(CodeSeen('S'))
             {
-              refresh_bed_level();
+              reset_bed_level();
               //set_bed_leveling_enabled(true);
               queue.enqueue_now_P(PSTR("M420 S1"));
               settings.save();
@@ -1442,7 +1443,7 @@ void AnycubicTFTClass::GetCommandFromTFT()
                 for (uint8_t y = 0; y < GRID_MAX_POINTS_Y; y++) {
                   temp_z_values[x][y] = NAN;
                 }
-              refresh_bed_level();
+              reset_bed_level();
               set_bed_leveling_enabled(true);
             }
 


### PR DESCRIPTION
### Description

Switch from AUTO_BED_LEVELING_BILINEAR to MESH_BED_LEVELING

### Benefits

* fixes issue where the movement of the carriage to the mesh points is super slow on MBL

### Related Issues

https://github.com/coolio986/Marlin_2.0.x_Anycubic_Chiron/issues/7 - thanks to MrJiffy for the actual solution
